### PR TITLE
Remove provider/client refs, add metadata

### DIFF
--- a/src/no-op-provider.ts
+++ b/src/no-op-provider.ts
@@ -6,7 +6,9 @@ const REASON_NO_OP = 'No-op';
  * The No-op provider is set by default, and simply always returns the default value.
  */
 class NoopFeatureProvider implements Provider {
-  readonly name = 'No-op Provider';
+  readonly metadata = {
+    name: 'No-op Provider',
+  } as const;
 
   resolveBooleanEvaluation(_: string, defaultValue: boolean): Promise<ResolutionDetails<boolean>> {
     return this.noOp(defaultValue);

--- a/src/open-feature.ts
+++ b/src/open-feature.ts
@@ -1,6 +1,6 @@
 import { OpenFeatureClient } from './client.js';
 import { NOOP_PROVIDER } from './no-op-provider.js';
-import { Client, EvaluationContext, FlagValue, Hook, Provider } from './types.js';
+import { Client, EvaluationContext, FlagValue, Hook, Provider, TransformingProvider } from './types.js';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
@@ -31,7 +31,15 @@ export class OpenFeature {
   }
 
   static getClient(name?: string, version?: string, context?: EvaluationContext): Client {
-    return new OpenFeatureClient(this.instance, { name, version }, context);
+    return new OpenFeatureClient(
+      () => this.instance._provider as TransformingProvider<unknown>,
+      { name, version },
+      context
+    );
+  }
+
+  static get providerMetadata() {
+    return this.instance._provider.metadata;
   }
 
   static addHooks(...hooks: Hook<FlagValue>[]): void {
@@ -42,12 +50,8 @@ export class OpenFeature {
     return this.instance._hooks;
   }
 
-  static set provider(provider: Provider) {
+  static setProvider(provider: Provider) {
     this.instance._provider = provider;
-  }
-
-  static get provider(): Provider {
-    return this.instance._provider;
   }
 
   static set context(context: EvaluationContext) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
 export type EvaluationContext = {
   /**
    * A string uniquely identifying the subject (end-user, or client service) of a flag evaluation.
@@ -103,7 +104,7 @@ export interface Features {
 export type ContextTransformer<T = unknown> = (context: EvaluationContext) => T;
 
 interface GenericProvider<T> {
-  name: string;
+  readonly metadata: ProviderMetadata;
 
   /**
    * Resolve a boolean flag and it's evaluation details.
@@ -187,19 +188,29 @@ export type EvaluationDetails<T extends FlagValue> = {
 } & ResolutionDetails<T>;
 
 export interface Client extends EvaluationLifeCycle, Features {
-  readonly name?: string;
-  readonly version?: string;
+  readonly metadata: ClientMetadata;
 }
 
 export type HookHints = Readonly<Record<string, unknown>>;
+
+interface Metadata {}
+
+export interface ClientMetadata extends Metadata {
+  readonly version?: string;
+  readonly name?: string;
+}
+
+export interface ProviderMetadata extends Metadata {
+  readonly name: string;
+}
 
 export interface HookContext<T extends FlagValue = FlagValue> {
   readonly flagKey: string;
   readonly defaultValue: T;
   readonly flagValueType: FlagValueType;
   readonly context: Readonly<EvaluationContext>;
-  readonly client: Client;
-  readonly provider: Provider;
+  readonly clientMetadata: ClientMetadata;
+  readonly providerMetadata: ProviderMetadata;
 }
 
 export interface BeforeHookContext extends HookContext {

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -25,8 +25,9 @@ const REASON = 'mocked-value';
 
 // a mock provider with some jest spies
 const MOCK_PROVIDER: Provider = {
-  name: 'mock',
-
+  metadata: {
+    name: 'mock',
+  },
   resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
     return Promise.resolve({
       value: BOOLEAN_VALUE,
@@ -60,7 +61,7 @@ const MOCK_PROVIDER: Provider = {
 
 describe(OpenFeatureClient.name, () => {
   beforeAll(() => {
-    OpenFeature.provider = MOCK_PROVIDER;
+    OpenFeature.setProvider(MOCK_PROVIDER);
   });
 
   afterEach(() => {
@@ -249,7 +250,7 @@ describe(OpenFeatureClient.name, () => {
       const defaultValue = 123;
 
       beforeAll(async () => {
-        OpenFeature.provider = errorProvider;
+        OpenFeature.setProvider(errorProvider);
         client = OpenFeature.getClient();
         details = await client.getNumberDetails('some-flag', defaultValue);
       });
@@ -296,7 +297,7 @@ describe(OpenFeatureClient.name, () => {
         const flagKey = 'some-flag';
         const defaultValue = false;
         const context = {};
-        OpenFeature.provider = transformingProvider;
+        OpenFeature.setProvider(transformingProvider);
         const client = OpenFeature.getClient();
         await client.getBooleanValue(flagKey, defaultValue, context);
 
@@ -325,7 +326,7 @@ describe(OpenFeatureClient.name, () => {
         const flagKey = 'some-other-flag';
         const defaultValue = false;
         const context = { transformed: false };
-        OpenFeature.provider = nonTransformingProvider;
+        OpenFeature.setProvider(nonTransformingProvider);
         const client = OpenFeature.getClient();
         await client.getBooleanValue(flagKey, defaultValue, context);
 

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -10,8 +10,9 @@ const ERROR_CODE = 'MOCKED_ERROR';
 
 // a mock provider with some jest spies
 const MOCK_PROVIDER: Provider = {
-  name: 'mock-hooks-success',
-
+  metadata: {
+    name: 'mock-hooks-success',
+  },
   resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
     return Promise.resolve({
       value: BOOLEAN_VALUE,
@@ -23,8 +24,9 @@ const MOCK_PROVIDER: Provider = {
 
 // a mock provider with some jest spies
 const MOCK_ERROR_PROVIDER: Provider = {
-  name: 'mock-hooks-error',
-
+  metadata: {
+    name: 'mock-hooks-error',
+  },
   resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
     return Promise.reject({
       reason: ERROR_REASON,
@@ -45,7 +47,7 @@ describe('Hooks', () => {
   });
 
   beforeAll(() => {
-    OpenFeature.provider = MOCK_PROVIDER;
+    OpenFeature.setProvider(MOCK_PROVIDER);
   });
 
   beforeEach(() => {
@@ -63,8 +65,8 @@ describe('Hooks', () => {
                 expect(hookContext.flagValueType).toBeDefined();
                 expect(hookContext.context).toBeDefined();
                 expect(hookContext.defaultValue).toBeDefined();
-                expect(hookContext.provider).toBeDefined();
-                expect(hookContext.client).toBeDefined();
+                expect(hookContext.providerMetadata).toBeDefined();
+                expect(hookContext.clientMetadata).toBeDefined();
                 done();
               } catch (err) {
                 done(err);
@@ -254,7 +256,7 @@ describe('Hooks', () => {
 
     describe('"error" stage', () => {
       beforeAll(() => {
-        OpenFeature.provider = MOCK_ERROR_PROVIDER;
+        OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
       });
 
       describe('Requirement 3.6', () => {
@@ -281,7 +283,7 @@ describe('Hooks', () => {
     describe('"finally" stage', () => {
       describe('Requirement 3.7', () => {
         it('"finally" must run after "after" stage', (done) => {
-          OpenFeature.provider = MOCK_PROVIDER;
+          OpenFeature.setProvider(MOCK_PROVIDER);
 
           const afterAndFinallyHook: Hook = {
             // mock "after"
@@ -305,7 +307,7 @@ describe('Hooks', () => {
         });
 
         it('"finally" must run after "error" stage', (done) => {
-          OpenFeature.provider = MOCK_ERROR_PROVIDER;
+          OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
 
           const errorAndFinallyHook: Hook = {
             error: jest.fn(() => {
@@ -331,7 +333,7 @@ describe('Hooks', () => {
 
     describe('Requirement 4.2', () => {
       it('"before" must run hook in order global, client, invocation', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -381,7 +383,7 @@ describe('Hooks', () => {
       });
 
       it('"after" must run hook in order invocation, client, global', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -431,7 +433,7 @@ describe('Hooks', () => {
       });
 
       it('"error" must run hook in order invocation, client, global', (done) => {
-        OpenFeature.provider = MOCK_ERROR_PROVIDER;
+        OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -481,7 +483,7 @@ describe('Hooks', () => {
       });
 
       it('"finally" must run hook in order invocation, client, global', (done) => {
-        OpenFeature.provider = MOCK_ERROR_PROVIDER;
+        OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -533,7 +535,7 @@ describe('Hooks', () => {
 
     describe('Requirement 4.3', () => {
       it('"finally" must not trigger error', (done) => {
-        OpenFeature.provider = MOCK_ERROR_PROVIDER;
+        OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -563,7 +565,7 @@ describe('Hooks', () => {
 
     describe('Requirement 4.4', () => {
       it('"before" must trigger error hook', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -587,7 +589,7 @@ describe('Hooks', () => {
       });
 
       it('"after" must trigger error hook', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -613,7 +615,7 @@ describe('Hooks', () => {
 
     describe('Requirement 4.5', () => {
       it('remaining hooks must not run after error', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -646,7 +648,7 @@ describe('Hooks', () => {
 
     describe('Requirement 5.2, 5.3', () => {
       it('HookHints should be passed to each hook', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -686,7 +688,7 @@ describe('Hooks', () => {
 
     describe('Requirement 5.4', () => {
       it('HookHints should be immutable', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.clearHooks();
         client.clearHooks();
 
@@ -722,7 +724,7 @@ describe('Hooks', () => {
   describe('async hooks', () => {
     describe('before, after, finally', () => {
       it('should be awaited, run in order', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
 
         const asyncBeforeAfterFinally: Hook = {
           before: jest.fn(() => {
@@ -759,7 +761,7 @@ describe('Hooks', () => {
 
     describe('before, error, finally', () => {
       it('should be awaited, run in order', (done) => {
-        OpenFeature.provider = MOCK_PROVIDER;
+        OpenFeature.setProvider(MOCK_PROVIDER);
 
         const asyncBeforeErroFinally = {
           before: jest.fn(() => {

--- a/test/open-feature.spec.ts
+++ b/test/open-feature.spec.ts
@@ -7,17 +7,11 @@ describe(OpenFeature.name, () => {
     jest.clearAllMocks();
   });
 
-  describe('Requirement 1.1', () => {
-    it('should be global singleton', () => {
-      expect(OpenFeature.provider === OpenFeature.provider).toBeTruthy();
-    });
-  });
-
   describe('Requirement 1.2', () => {
     it('should equal previously set provider', () => {
-      const fakeProvider = {} as Provider;
-      OpenFeature.provider = fakeProvider;
-      expect(OpenFeature.provider === fakeProvider).toBeTruthy();
+      const fakeProvider = { metadata: 'test' } as unknown as Provider;
+      OpenFeature.setProvider(fakeProvider);
+      expect(OpenFeature.providerMetadata === fakeProvider.metadata).toBeTruthy();
     });
   });
 
@@ -29,7 +23,7 @@ describe(OpenFeature.name, () => {
 
   describe('Requirement 1.4', () => {
     it('should implement a provider accessor and mutator', () => {
-      expect(OpenFeature.provider).toBeDefined();
+      expect(OpenFeature.providerMetadata).toBeDefined();
     });
   });
 
@@ -43,7 +37,7 @@ describe(OpenFeature.name, () => {
 
       // check that using a named configuration also works as expected.
       expect(namedClient).toBeInstanceOf(OpenFeatureClient);
-      expect(namedClient.name).toEqual(name);
+      expect(namedClient.metadata.name).toEqual(name);
     });
   });
 });


### PR DESCRIPTION
Removes refs to provider, client in `hookContext` (replacing with metadata), and provider accessor from API.