### PR TITLE
feat: add support for Date and JSON objects

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,17 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
+/**
+ * Represents a JSON value of a JSON object
+ */
+export type JSONValue = null | string | number | boolean | Date | { [x: string]: JSONValue } | Array<JSONValue>;
+
+
 export type EvaluationContext = {
   /**
    * A string uniquely identifying the subject (end-user, or client service) of a flag evaluation.
    * Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users. Such providers may behave unpredictably if a targeting key is not specified at flag resolution.
    */
   targetingKey?: string;
-} & Record<string, string | number | boolean | Date>;
+} & Record<string, JSONValue>;
 
 export type FlagValue = boolean | string | number | object;
 

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -17,6 +17,8 @@ const NUMBER_VALUE = 2034;
 const OBJECT_VALUE = {
   key: 'value',
 };
+const DATETIME_VALUE = new Date(2022, 5, 13, 18, 20, 0);
+
 const BOOLEAN_VARIANT = `${BOOLEAN_VALUE}`;
 const STRING_VARIANT = `${STRING_VALUE}-variant`;
 const NUMBER_VARIANT = NUMBER_VALUE.toString();

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -340,4 +340,38 @@ describe(OpenFeatureClient.name, () => {
       });
     });
   });
+
+  describe('Requirement 3.1', () => {
+    const transformingProvider = {
+      name: 'evaluation-context',
+      contextTransformer: jest.fn((context: EvaluationContext) => {
+        return { ...context };
+      }),
+      resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
+        return Promise.resolve({
+          value: true,
+        });
+      }),
+    } as unknown as TransformingProvider<EvaluationContext>;
+    it('context should support boolean | string | number | datetime | structure', async () => {
+      const flagKey = 'some-other-flag';
+      const defaultValue = false;
+      const context = {
+        booleanField: BOOLEAN_VALUE,
+        stringField: STRING_VALUE,
+        numberField: NUMBER_VALUE,
+        datetimeField: DATETIME_VALUE,
+        structureField: OBJECT_VALUE,
+      };
+
+      OpenFeature.setProvider(transformingProvider);
+      const client = OpenFeature.getClient();
+      await client.getBooleanValue(flagKey, defaultValue, context);
+      expect(transformingProvider.contextTransformer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...context,
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Add support for `Date` and `JSON objects` in the evaluation context as
defined in Requirement 3.1 of the Evaulation Context specification

refs #23