### PR TITLE
Removing constructor, not exported anymore

### DIFF
--- a/src/open-feature.ts
+++ b/src/open-feature.ts
@@ -1,6 +1,14 @@
 import { OpenFeatureClient } from './client.js';
 import { NOOP_PROVIDER } from './no-op-provider.js';
-import { Client, EvaluationContext, EvaluationLifeCycle, FlagValue, Hook, Provider, TransformingProvider } from './types.js';
+import {
+  Client,
+  EvaluationContext,
+  EvaluationLifeCycle,
+  FlagValue,
+  Hook,
+  Provider,
+  TransformingProvider,
+} from './types.js';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
@@ -15,9 +23,6 @@ class OpenFeatureAPI implements EvaluationLifeCycle {
   private _context: EvaluationContext = {};
   private _hooks: Hook[] = [];
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  protected constructor() {}
-
   static getInstance(): OpenFeatureAPI {
     const globalApi = _global[GLOBAL_OPENFEATURE_API_KEY];
     if (globalApi) {
@@ -30,11 +35,7 @@ class OpenFeatureAPI implements EvaluationLifeCycle {
   }
 
   getClient(name?: string, version?: string, context?: EvaluationContext): Client {
-    return new OpenFeatureClient(
-      () => this._provider as TransformingProvider<unknown>,
-      { name, version },
-      context
-    );
+    return new OpenFeatureClient(() => this._provider as TransformingProvider<unknown>, { name, version }, context);
   }
 
   get providerMetadata() {


### PR DESCRIPTION
Very small change to remove protected constructor which we only needed since the class was previously exported and we didn't want people instantiating it. Now since it's not exported we can use the default constructor.