### PR TITLE
Export the abstract error

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -2,3 +2,4 @@ export * from './codes.js';
 export * from './flag-not-found-error.js';
 export * from './parse-error.js';
 export * from './type-mismatch-error.js';
+export * from './error-abstract.js';


### PR DESCRIPTION
The `OpenFeatureError` abstract class is not public and is used only internally.

It could be great to let people developing **providers** and **hooks** extend it to have the right format when creating new types of errors.
Without that we can only use these errors :
- `FlagNotFoundError`
- `ParseError`
- `TypeMismatchError`

