### PR TITLE
fix: Fixing error with setProvider type

### DIFF
--- a/src/open-feature.ts
+++ b/src/open-feature.ts
@@ -6,6 +6,7 @@ import {
   EvaluationLifeCycle,
   FlagValue,
   Hook,
+  NonTransformingProvider,
   Provider,
   TransformingProvider,
 } from './types.js';
@@ -50,7 +51,7 @@ class OpenFeatureAPI implements EvaluationLifeCycle {
     return this._hooks;
   }
 
-  setProvider(provider: Provider) {
+  setProvider(provider: TransformingProvider<unknown> | NonTransformingProvider) {
     this._provider = provider;
   }
 


### PR DESCRIPTION
Provider is a conditional type. Using it here is incorrect because we are basically saying that we know the provider to be only one of the two possible types expressed [here](https://github.com/open-feature/node-sdk/blob/a37d0fcd855579e3cdac12e2e13955899f74521b/src/types.ts#L170). This method needs to handle both. The simple solution is to allow this method to handle either provider type, not the conditional type.

Closes: https://github.com/open-feature/node-sdk/issues/119

I tested this with a local publish BTW, it seems to fix @thomaspoignant 's issue.