### PR TITLE
feat!: remove flag evaluation options from the provider interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 [![codecov](https://codecov.io/gh/open-feature/node-sdk/branch/main/graph/badge.svg?token=3DC5XOEHMY)](https://codecov.io/gh/open-feature/node-sdk)
 [![npm version](https://badge.fury.io/js/@openfeature%2Fnodejs-sdk.svg)](https://badge.fury.io/js/@openfeature%2Fnodejs-sdk)
 [![Known Vulnerabilities](https://snyk.io/test/github/open-feature/node-sdk/badge.svg)](https://snyk.io/test/github/open-feature/node-sdk)
+[![Specification](https://img.shields.io/static/v1?label=Specification&message=v0.4.0&color=yellow)](https://github.com/open-feature/spec/tree/v0.4.0)
 
 This is the NodeJS implementation of [OpenFeature](https://openfeature.dev), a vendor-agnostic abstraction library for evaluating feature flags.
 
-We support multiple data types for flags (numbers, strings, booleans, objects) as well as  hooks, which can alter the lifecycle of a flag evaluation.
+We support multiple data types for flags (numbers, strings, booleans, objects) as well as hooks, which can alter the lifecycle of a flag evaluation.
 
 This library is intended to be used in server-side contexts and has not been evaluated for use in mobile devices.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,8 +118,7 @@ export interface Provider extends Pick<Partial<EvaluationLifeCycle>, 'hooks'> {
   resolveBooleanEvaluation(
     flagKey: string,
     defaultValue: boolean,
-    context: EvaluationContext,
-    options: FlagEvaluationOptions | undefined
+    context: EvaluationContext
   ): Promise<ResolutionDetails<boolean>>;
 
   /**
@@ -128,8 +127,7 @@ export interface Provider extends Pick<Partial<EvaluationLifeCycle>, 'hooks'> {
   resolveStringEvaluation(
     flagKey: string,
     defaultValue: string,
-    context: EvaluationContext,
-    options: FlagEvaluationOptions | undefined
+    context: EvaluationContext
   ): Promise<ResolutionDetails<string>>;
 
   /**
@@ -138,8 +136,7 @@ export interface Provider extends Pick<Partial<EvaluationLifeCycle>, 'hooks'> {
   resolveNumberEvaluation(
     flagKey: string,
     defaultValue: number,
-    context: EvaluationContext,
-    options: FlagEvaluationOptions | undefined
+    context: EvaluationContext
   ): Promise<ResolutionDetails<number>>;
 
   /**
@@ -148,8 +145,7 @@ export interface Provider extends Pick<Partial<EvaluationLifeCycle>, 'hooks'> {
   resolveObjectEvaluation<U extends object>(
     flagKey: string,
     defaultValue: U,
-    context: EvaluationContext,
-    options: FlagEvaluationOptions | undefined
+    context: EvaluationContext
   ): Promise<ResolutionDetails<U>>;
 }
 


### PR DESCRIPTION
Closes #183 