### PR TITLE
feat!: convert to chainable methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
 	"extends":[
 		 "eslint:recommended",
 		 "plugin:@typescript-eslint/recommended",
-		 "prettier"
+		 "prettier",
+		 "plugin:jsdoc/recommended"
 	],
 	"parser":"@typescript-eslint/parser",
 	"parserOptions":{
@@ -15,7 +16,8 @@
 	},
 	"plugins":[
 		 "@typescript-eslint",
-		 "check-file"
+		 "check-file",
+		 "jsdoc"
 	],
 	"rules":{
 		 "linebreak-style":[
@@ -38,6 +40,6 @@
       {
       	"ignoreMiddleExtensions": true
       }
-	 ]
+		]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-check-file": "^1.2.1",
         "eslint-plugin-jest": "^27.0.1",
+        "eslint-plugin-jsdoc": "^39.3.6",
         "jest": "^28.1.0",
         "jest-junit": "^14.0.0",
         "prettier": "^2.6.2",
@@ -648,6 +649,20 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
+      "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
@@ -2365,6 +2380,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3023,6 +3047,27 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "39.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz",
+      "integrity": "sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -4842,6 +4887,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5604,6 +5658,28 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -6635,6 +6711,17 @@
       "optional": true,
       "requires": {
         "esbuild-wasm": "0.15.8"
+      }
+    },
+    "@es-joy/jsdoccomment": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
+      "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
       }
     },
     "@esbuild/linux-loong64": {
@@ -7931,6 +8018,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8356,6 +8449,21 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "39.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz",
+      "integrity": "sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
       }
     },
     "eslint-scope": {
@@ -9744,6 +9852,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -10285,6 +10399,28 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-check-file": "^1.2.1",
     "eslint-plugin-jest": "^27.0.1",
+    "eslint-plugin-jsdoc": "^39.3.6",
     "jest": "^28.1.0",
     "jest-junit": "^14.0.0",
     "prettier": "^2.6.2",

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,34 +42,80 @@ export class OpenFeatureClient implements Client {
     this._context = context;
   }
 
-  set logger(logger: Logger) {
+  /**
+   * Sets a logger on the client. This logger supersedes to the global logger
+   * and is passed to various components in the SDK.
+   *
+   * @param {Logger} logger The logger to to be used
+   * @returns {OpenFeatureClient} OpenFeature Client
+   */
+  setLogger(logger: Logger): OpenFeatureClient {
     this._clientLogger = new SafeLogger(logger);
+    return this;
   }
 
-  get logger(): Logger {
-    return this._clientLogger || this.globalLogger();
-  }
-
-  set context(context: EvaluationContext) {
+  /**
+   * Sets client evaluation context that will be used during flag evaluations
+   * on this client.
+   *
+   * @param {EvaluationContext} context Client evaluation context
+   * @returns {OpenFeatureClient} OpenFeature Client
+   */
+  setContext(context: EvaluationContext): OpenFeatureClient {
     this._context = context;
+    return this;
   }
 
-  get context(): EvaluationContext {
+  /**
+   * Access the client evaluation context.
+   *
+   * @returns {EvaluationContext} Client evaluation context
+   */
+  getContext(): EvaluationContext {
     return this._context;
   }
 
-  addHooks(...hooks: Hook<FlagValue>[]): void {
+  /**
+   * Adds client hooks that will run during flag evaluations on this client. Client
+   * hooks are executed in the order they were registered. Adding additional hooks
+   * will not remove existing hooks.
+   *
+   * @param {Hook<FlagValue>[]} hooks A list of hooks that should always run
+   * @returns {OpenFeatureClient} OpenFeature Client
+   */
+  addHooks(...hooks: Hook<FlagValue>[]): OpenFeatureClient {
     this._hooks = [...this._hooks, ...hooks];
+    return this;
   }
 
-  get hooks(): Hook<FlagValue>[] {
+  /**
+   * Access all the hooks that are registered on this client.
+   *
+   * @returns {Hook<FlagValue>[]} A list of the client hooks
+   */
+  getHooks(): Hook<FlagValue>[] {
     return this._hooks;
   }
 
-  clearHooks(): void {
+  /**
+   * Clears all the hooks that are registered on this client.
+   *
+   * @returns {OpenFeatureClient} OpenFeature Client
+   */
+  clearHooks(): OpenFeatureClient {
     this._hooks = [];
+    return this;
   }
 
+  /**
+   * Performs a flag evaluation that returns a boolean.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {boolean} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<boolean>} Flag evaluation response
+   */
   async getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
@@ -79,6 +125,15 @@ export class OpenFeatureClient implements Client {
     return (await this.getBooleanDetails(flagKey, defaultValue, context, options)).value;
   }
 
+  /**
+   * Performs a flag evaluation that a returns an evaluation details object.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {boolean} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<EvaluationDetails<boolean>>} Flag evaluation details response
+   */
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
@@ -87,7 +142,7 @@ export class OpenFeatureClient implements Client {
   ): Promise<EvaluationDetails<boolean>> {
     return this.evaluate<boolean>(
       flagKey,
-      this.provider.resolveBooleanEvaluation,
+      this._provider.resolveBooleanEvaluation,
       defaultValue,
       'boolean',
       context,
@@ -95,6 +150,15 @@ export class OpenFeatureClient implements Client {
     );
   }
 
+  /**
+   * Performs a flag evaluation that returns a string.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {string} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<string>} Flag evaluation response
+   */
   async getStringValue(
     flagKey: string,
     defaultValue: string,
@@ -104,6 +168,15 @@ export class OpenFeatureClient implements Client {
     return (await this.getStringDetails(flagKey, defaultValue, context, options)).value;
   }
 
+  /**
+   * Performs a flag evaluation that a returns an evaluation details object.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {boolean} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<EvaluationDetails<string>>} Flag evaluation details response
+   */
   getStringDetails(
     flagKey: string,
     defaultValue: string,
@@ -112,7 +185,7 @@ export class OpenFeatureClient implements Client {
   ): Promise<EvaluationDetails<string>> {
     return this.evaluate<string>(
       flagKey,
-      this.provider.resolveStringEvaluation,
+      this._provider.resolveStringEvaluation,
       defaultValue,
       'string',
       context,
@@ -120,6 +193,15 @@ export class OpenFeatureClient implements Client {
     );
   }
 
+  /**
+   * Performs a flag evaluation that returns a number.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {number} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<number>} Flag evaluation response
+   */
   async getNumberValue(
     flagKey: string,
     defaultValue: number,
@@ -129,6 +211,15 @@ export class OpenFeatureClient implements Client {
     return (await this.getNumberDetails(flagKey, defaultValue, context, options)).value;
   }
 
+  /**
+   * Performs a flag evaluation that a returns an evaluation details object.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {number} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<EvaluationDetails<number>>} Flag evaluation details response
+   */
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
@@ -137,7 +228,7 @@ export class OpenFeatureClient implements Client {
   ): Promise<EvaluationDetails<number>> {
     return this.evaluate<number>(
       flagKey,
-      this.provider.resolveNumberEvaluation,
+      this._provider.resolveNumberEvaluation,
       defaultValue,
       'number',
       context,
@@ -145,6 +236,15 @@ export class OpenFeatureClient implements Client {
     );
   }
 
+  /**
+   * Performs a flag evaluation that returns an object.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {object} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<object>} Flag evaluation response
+   */
   async getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
@@ -154,13 +254,22 @@ export class OpenFeatureClient implements Client {
     return (await this.getObjectDetails(flagKey, defaultValue, context, options)).value;
   }
 
+  /**
+   * Performs a flag evaluation that a returns an evaluation details object.
+   *
+   * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @param {object} defaultValue The value returned if an error occurs
+   * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
+   * @param {FlagEvaluationOptions} options Additional flag evaluation options
+   * @returns {Promise<EvaluationDetails<object>>} Flag evaluation details response
+   */
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
   ): Promise<EvaluationDetails<T>> {
-    return this.evaluate<T>(flagKey, this.provider.resolveObjectEvaluation, defaultValue, 'object', context, options);
+    return this.evaluate<T>(flagKey, this._provider.resolveObjectEvaluation, defaultValue, 'object', context, options);
   }
 
   private async evaluate<T extends FlagValue>(
@@ -178,12 +287,17 @@ export class OpenFeatureClient implements Client {
   ): Promise<EvaluationDetails<T>> {
     // merge global, client, and evaluation context
 
-    const allHooks = [...OpenFeature.hooks, ...this.hooks, ...(options.hooks || []), ...(this.provider.hooks || [])];
+    const allHooks = [
+      ...OpenFeature.getHooks(),
+      ...this.getHooks(),
+      ...(options.hooks || []),
+      ...(this._provider.hooks || []),
+    ];
     const allHooksReversed = [...allHooks].reverse();
 
     // merge global and client contexts
     const mergedContext = {
-      ...OpenFeature.context,
+      ...OpenFeature.getContext(),
       ...this._context,
       ...invocationContext,
     };
@@ -197,14 +311,14 @@ export class OpenFeatureClient implements Client {
       clientMetadata: this.metadata,
       providerMetadata: OpenFeature.providerMetadata,
       context: mergedContext,
-      logger: this.logger,
+      logger: this._logger,
     };
 
     try {
       const frozenContext = await this.beforeHooks(allHooks, hookContext, options);
 
       // run the referenced resolver, binding the provider.
-      const resolution = await resolver.call(this.provider, flagKey, defaultValue, frozenContext, this.logger);
+      const resolution = await resolver.call(this._provider, flagKey, defaultValue, frozenContext, this._logger);
 
       const evaluationDetails = {
         ...resolution,
@@ -264,14 +378,11 @@ export class OpenFeatureClient implements Client {
       try {
         await hook?.error?.(hookContext, err, options.hookHints);
       } catch (err) {
-        this.logger.error(`Unhandled error during 'error' hook: ${err}`);
-<<<<<<< HEAD
+        this._logger.error(`Unhandled error during 'error' hook: ${err}`);
         if (err instanceof Error) {
-          this.logger.error(err.stack);
+          this._logger.error(err.stack);
         }
-=======
-        this.logger.error((err as Error)?.stack);
->>>>>>> add logger
+        this._logger.error((err as Error)?.stack);
       }
     }
   }
@@ -282,19 +393,20 @@ export class OpenFeatureClient implements Client {
       try {
         await hook?.finally?.(hookContext, options.hookHints);
       } catch (err) {
-        this.logger.error(`Unhandled error during 'finally' hook: ${err}`);
-<<<<<<< HEAD
+        this._logger.error(`Unhandled error during 'finally' hook: ${err}`);
         if (err instanceof Error) {
-          this.logger.error(err.stack);
+          this._logger.error(err.stack);
         }
-=======
-        this.logger.error((err as Error)?.stack);
->>>>>>> add logger
+        this._logger.error((err as Error)?.stack);
       }
     }
   }
 
-  private get provider() {
+  private get _provider() {
     return this.providerAccessor();
+  }
+
+  private get _logger() {
+    return this._clientLogger || this.globalLogger();
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -55,7 +55,7 @@ export class OpenFeatureClient implements Client {
   }
 
   /**
-   * Sets client evaluation context that will be used during flag evaluations
+   * Sets evaluation context that will be used during flag evaluations
    * on this client.
    *
    * @param {EvaluationContext} context Client evaluation context
@@ -67,7 +67,7 @@ export class OpenFeatureClient implements Client {
   }
 
   /**
-   * Access the client evaluation context.
+   * Access the evaluation context set on the client.
    *
    * @returns {EvaluationContext} Client evaluation context
    */
@@ -76,7 +76,7 @@ export class OpenFeatureClient implements Client {
   }
 
   /**
-   * Adds client hooks that will run during flag evaluations on this client. Client
+   * Adds hooks that will run during flag evaluations on this client. Client
    * hooks are executed in the order they were registered. Adding additional hooks
    * will not remove existing hooks.
    *

--- a/src/client.ts
+++ b/src/client.ts
@@ -265,9 +265,13 @@ export class OpenFeatureClient implements Client {
         await hook?.error?.(hookContext, err, options.hookHints);
       } catch (err) {
         this.logger.error(`Unhandled error during 'error' hook: ${err}`);
+<<<<<<< HEAD
         if (err instanceof Error) {
           this.logger.error(err.stack);
         }
+=======
+        this.logger.error((err as Error)?.stack);
+>>>>>>> add logger
       }
     }
   }
@@ -279,9 +283,13 @@ export class OpenFeatureClient implements Client {
         await hook?.finally?.(hookContext, options.hookHints);
       } catch (err) {
         this.logger.error(`Unhandled error during 'finally' hook: ${err}`);
+<<<<<<< HEAD
         if (err instanceof Error) {
           this.logger.error(err.stack);
         }
+=======
+        this.logger.error((err as Error)?.stack);
+>>>>>>> add logger
       }
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,7 +27,11 @@ export class SafeLogger implements Logger {
       this.logger = logger;
     } catch (err) {
       console.error(err);
+<<<<<<< HEAD
       console.error('Falling back to the default logger.');
+=======
+      console.warn('Falling back to the default logger.');
+>>>>>>> add logger
       this.logger = this.fallbackLogger;
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,11 +27,7 @@ export class SafeLogger implements Logger {
       this.logger = logger;
     } catch (err) {
       console.error(err);
-<<<<<<< HEAD
       console.error('Falling back to the default logger.');
-=======
-      console.warn('Falling back to the default logger.');
->>>>>>> add logger
       this.logger = this.fallbackLogger;
     }
   }

--- a/src/open-feature.ts
+++ b/src/open-feature.ts
@@ -1,7 +1,7 @@
 import { OpenFeatureClient } from './client';
 import { DefaultLogger, SafeLogger } from './logger';
 import { NOOP_PROVIDER } from './no-op-provider';
-import { Client, EvaluationContext, EvaluationLifeCycle, FlagValue, Hook, Logger, Provider } from './types';
+import { Client, EvaluationContext, FlagValue, GlobalApi, Hook, Logger, Provider, ProviderMetadata } from './types';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
@@ -11,7 +11,7 @@ type OpenFeatureGlobal = {
 };
 const _global = global as OpenFeatureGlobal;
 
-class OpenFeatureAPI implements EvaluationLifeCycle {
+class OpenFeatureAPI implements GlobalApi {
   private _provider: Provider = NOOP_PROVIDER;
   private _context: EvaluationContext = {};
   private _hooks: Hook[] = [];
@@ -28,14 +28,29 @@ class OpenFeatureAPI implements EvaluationLifeCycle {
     return instance;
   }
 
-  set logger(logger: Logger) {
+  /**
+   * Sets a logger that used globally within OpenFeature. This logger supersedes
+   * to the default logger and is passed to various components in the SDK. The
+   * global logger can be overridden per client.
+   *
+   * @param {Logger} logger The logger to to be used
+   * @returns {OpenFeatureAPI} OpenFeature API
+   */
+  setLogger(logger: Logger): OpenFeatureAPI {
     this._logger = new SafeLogger(logger);
+    return this;
   }
 
-  get logger() {
-    return this._logger;
-  }
-
+  /**
+   * A factory function for creating new OpenFeature clients. Clients can contain
+   * their own state (e.g. logger, hook, context). Multiple clients can be used
+   * to segment feature flag configuration.
+   *
+   * @param {string} name The name of the client
+   * @param {string} version The version of the client
+   * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
+   * @returns {Client} OpenFeature Client
+   */
   getClient(name?: string, version?: string, context?: EvaluationContext): Client {
     return new OpenFeatureClient(
       () => this._provider,
@@ -45,32 +60,79 @@ class OpenFeatureAPI implements EvaluationLifeCycle {
     );
   }
 
-  get providerMetadata() {
+  /**
+   * Get metadata about registered provider.
+   *
+   * @returns {ProviderMetadata} Provider Metadata
+   */
+  get providerMetadata(): ProviderMetadata {
     return this._provider.metadata;
   }
 
-  addHooks(...hooks: Hook<FlagValue>[]): void {
+  /**
+   * Adds global hooks that will always run during a flag evaluation. Global
+   * hooks are executed in the order that they were registered. Adding additional
+   * hooks will not remove existing hooks.
+   *
+   * @param {Hook<FlagValue>[]} hooks A list of hooks that should always run
+   * @returns {OpenFeatureAPI} OpenFeature API
+   */
+  addHooks(...hooks: Hook<FlagValue>[]): OpenFeatureAPI {
     this._hooks = [...this._hooks, ...hooks];
+    return this;
   }
 
-  get hooks(): Hook<FlagValue>[] {
+  /**
+   * Access all the hooks that are globally registered.
+   *
+   * @returns {Hook<FlagValue>[]} A list of the global hooks
+   */
+  getHooks(): Hook<FlagValue>[] {
     return this._hooks;
   }
 
-  setProvider(provider: Provider) {
-    this._provider = provider;
-  }
-
-  set context(context: EvaluationContext) {
-    this._context = context;
-  }
-
-  get context(): EvaluationContext {
-    return this._context;
-  }
-
-  clearHooks(): void {
+  /**
+   * Clears all the globally registered hooks.
+   *
+   * @returns {OpenFeatureAPI} OpenFeature API
+   */
+  clearHooks(): OpenFeatureAPI {
     this._hooks = [];
+    return this;
+  }
+
+  /**
+   * Sets the provider that OpenFeature will use for flag evaluations. Setting
+   * a provider supersedes the current provider used in new and existing clients.
+   *
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {OpenFeatureAPI} OpenFeature API
+   */
+  setProvider(provider: Provider): OpenFeatureAPI {
+    this._provider = provider;
+    return this;
+  }
+
+  /**
+   * Sets a global evaluation context that will be used during all flag evaluations.
+   * This is useful for evaluation context properties that are static (e.g. region,
+   * environment, hostname).
+   *
+   * @param {EvaluationContext} context Global evaluation context
+   * @returns {OpenFeatureAPI} OpenFeature API
+   */
+  setContext(context: EvaluationContext): OpenFeatureAPI {
+    this._context = context;
+    return this;
+  }
+
+  /**
+   * Access the global evaluation context.
+   *
+   * @returns {EvaluationContext} Global evaluation context
+   */
+  getContext(): EvaluationContext {
+    return this._context;
   }
 }
 

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -392,8 +392,7 @@ describe('OpenFeatureClient', () => {
           beforeHookContextValue: 'jkl',
         };
 
-        OpenFeature.setProvider(provider);
-        OpenFeature.context = globalContext;
+        OpenFeature.setProvider(provider).setContext(globalContext);
         const client = OpenFeature.getClient('contextual', 'test', clientContext);
         client.addHooks({ before: () => beforeHookContext });
         await client.getBooleanValue(flagKey, defaultValue, invocationContext);
@@ -417,9 +416,17 @@ describe('OpenFeatureClient', () => {
         const KEY = 'key';
         const VAL = 'val';
         const client = OpenFeature.getClient();
-        client.context = { [KEY]: VAL };
-        expect(client.context[KEY]).toEqual(VAL);
+        client.setContext({ [KEY]: VAL });
+        expect(client.getContext()[KEY]).toEqual(VAL);
       });
     });
+  });
+
+  it('should be chainable', async () => {
+    const client = OpenFeature.getClient();
+
+    expect(await client.addHooks().clearHooks().setContext({}).setLogger(console).getBooleanValue('test', true)).toBe(
+      true
+    );
   });
 });

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -212,10 +212,10 @@ describe('Hooks', () => {
       const invocationPropToOverwrite434 = 'invocationPropToOverwrite';
       const hookProp434 = 'hookProp';
 
-      OpenFeature.context = {
+      OpenFeature.setContext({
         [globalProp434]: true,
         [globalPropToOverwrite434]: false,
-      };
+      });
       const clientContext = {
         [clientProp434]: true,
         [clientPropToOverwrite434]: false,

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -131,8 +131,8 @@ describe('Logger', () => {
       });
 
       it('should create a safe logger', () => {
-        OpenFeature.logger = {} as Logger;
-        expect(OpenFeature.logger).toBeInstanceOf(SafeLogger);
+        OpenFeature.setLogger({} as Logger);
+        expect(OpenFeature['_logger']).toBeInstanceOf(SafeLogger);
       });
     });
 

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -9,7 +9,6 @@ class MockedLogger implements Logger {
   debug = jest.fn();
 }
 
-<<<<<<< HEAD
 const BEFORE_HOOK_LOG_MESSAGE = 'in before hook';
 const AFTER_HOOK_LOG_MESSAGE = 'in after hook';
 const ERROR_HOOK_LOG_MESSAGE = 'in error hook';
@@ -43,31 +42,6 @@ const MOCK_PROVIDER: Provider = {
   }),
   resolveObjectEvaluation: jest.fn((key, value, ctx, log) => {
     log.info(RESOLVE_OBJECT_MESSAGE);
-=======
-const MOCK_HOOK: Hook = {
-  before: jest.fn((hookContext) => hookContext.logger.info('in before hook')),
-  after: jest.fn((hookContext) => hookContext.logger.info('in after hook')),
-  error: jest.fn((hookContext) => hookContext.logger.info('in error hook')),
-  finally: jest.fn((hookContext) => hookContext.logger.info('in finally hook')),
-};
-
-const MOCK_PROVIDER: Provider = {
-  metadata: { name: 'Mock Provider' },
-  resolveBooleanEvaluation: jest.fn((key, value, ctx, log) => {
-    log.info('resolving boolean value');
-    return Promise.resolve({ value });
-  }),
-  resolveStringEvaluation: jest.fn((key, value, ctx, log) => {
-    log.info('resolving string value');
-    return Promise.resolve({ value });
-  }),
-  resolveNumberEvaluation: jest.fn((key, value, ctx, log) => {
-    log.info('resolving number value');
-    return Promise.resolve({ value });
-  }),
-  resolveObjectEvaluation: jest.fn((key, value, ctx, log) => {
-    log.info('resolving object value');
->>>>>>> add logger
     return Promise.resolve({ value });
   }),
 };
@@ -117,11 +91,7 @@ describe('Logger', () => {
     describe('Safe Logger', () => {
       it('should use the default logger because the custom logger is missing a function', () => {
         const errorSpy = jest.spyOn(global.console, 'error').mockImplementation();
-<<<<<<< HEAD
         const safeLogger = new SafeLogger({} as Logger);
-=======
-        const safeLogger = new SafeLogger({} as any);
->>>>>>> add logger
 
         expect(errorSpy).toBeCalledWith(
           expect.objectContaining({ message: 'The provided logger is missing the error method.' })
@@ -161,11 +131,7 @@ describe('Logger', () => {
       });
 
       it('should create a safe logger', () => {
-<<<<<<< HEAD
         OpenFeature.logger = {} as Logger;
-=======
-        OpenFeature.logger = {} as any;
->>>>>>> add logger
         expect(OpenFeature.logger).toBeInstanceOf(SafeLogger);
       });
     });
@@ -181,11 +147,7 @@ describe('Logger', () => {
       const mockedLogger = new MockedLogger();
       client.logger = mockedLogger;
       await client.getBooleanValue('test', false);
-<<<<<<< HEAD
       expect(mockedLogger.info).toHaveBeenCalledWith(RESOLVE_BOOL_MESSAGE);
-=======
-      expect(mockedLogger.info).toHaveBeenCalledWith('resolving boolean value');
->>>>>>> add logger
     });
 
     it('should provide a logger to the before, after, and finally hook', async () => {
@@ -196,7 +158,6 @@ describe('Logger', () => {
       await client.getBooleanValue('test', false);
 
       expect(mockedLogger.info.mock.calls).toEqual([
-<<<<<<< HEAD
         [BEFORE_HOOK_LOG_MESSAGE],
         [RESOLVE_BOOL_MESSAGE],
         [AFTER_HOOK_LOG_MESSAGE],
@@ -205,31 +166,17 @@ describe('Logger', () => {
     });
 
     it('should provide a logger to the error hook', async () => {
-=======
-        ['in before hook'],
-        ['resolving boolean value'],
-        ['in after hook'],
-        ['in finally hook'],
-      ]);
-    });
-
-    it('should use the default logger in the error hook', async () => {
->>>>>>> add logger
       const client = OpenFeature.getClient();
       const mockedLogger = new MockedLogger();
       client.logger = mockedLogger;
       client.addHooks(MOCK_HOOK);
       (MOCK_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockRejectedValueOnce('Run error hook');
       await client.getBooleanValue('test', false);
-<<<<<<< HEAD
       expect(mockedLogger.info.mock.calls).toEqual([
         [BEFORE_HOOK_LOG_MESSAGE],
         [ERROR_HOOK_LOG_MESSAGE],
         [FINALLY_HOOK_LOG_MESSAGE],
       ]);
-=======
-      expect(mockedLogger.info.mock.calls).toEqual([['in before hook'], ['in error hook'], ['in finally hook']]);
->>>>>>> add logger
     });
   });
 });

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -136,16 +136,10 @@ describe('Logger', () => {
       });
     });
 
-    it('should be an instance of the default logger', () => {
-      const client = OpenFeature.getClient();
-
-      expect(client.logger).toBeInstanceOf(DefaultLogger);
-    });
-
     it('should provide a logger to the provider', async () => {
       const client = OpenFeature.getClient();
       const mockedLogger = new MockedLogger();
-      client.logger = mockedLogger;
+      client.setLogger(mockedLogger);
       await client.getBooleanValue('test', false);
       expect(mockedLogger.info).toHaveBeenCalledWith(RESOLVE_BOOL_MESSAGE);
     });
@@ -153,7 +147,7 @@ describe('Logger', () => {
     it('should provide a logger to the before, after, and finally hook', async () => {
       const client = OpenFeature.getClient();
       const mockedLogger = new MockedLogger();
-      client.logger = mockedLogger;
+      client.setLogger(mockedLogger);
       client.addHooks(MOCK_HOOK);
       await client.getBooleanValue('test', false);
 
@@ -168,7 +162,7 @@ describe('Logger', () => {
     it('should provide a logger to the error hook', async () => {
       const client = OpenFeature.getClient();
       const mockedLogger = new MockedLogger();
-      client.logger = mockedLogger;
+      client.setLogger(mockedLogger);
       client.addHooks(MOCK_HOOK);
       (MOCK_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockRejectedValueOnce('Run error hook');
       await client.getBooleanValue('test', false);

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -9,6 +9,7 @@ class MockedLogger implements Logger {
   debug = jest.fn();
 }
 
+<<<<<<< HEAD
 const BEFORE_HOOK_LOG_MESSAGE = 'in before hook';
 const AFTER_HOOK_LOG_MESSAGE = 'in after hook';
 const ERROR_HOOK_LOG_MESSAGE = 'in error hook';
@@ -42,6 +43,31 @@ const MOCK_PROVIDER: Provider = {
   }),
   resolveObjectEvaluation: jest.fn((key, value, ctx, log) => {
     log.info(RESOLVE_OBJECT_MESSAGE);
+=======
+const MOCK_HOOK: Hook = {
+  before: jest.fn((hookContext) => hookContext.logger.info('in before hook')),
+  after: jest.fn((hookContext) => hookContext.logger.info('in after hook')),
+  error: jest.fn((hookContext) => hookContext.logger.info('in error hook')),
+  finally: jest.fn((hookContext) => hookContext.logger.info('in finally hook')),
+};
+
+const MOCK_PROVIDER: Provider = {
+  metadata: { name: 'Mock Provider' },
+  resolveBooleanEvaluation: jest.fn((key, value, ctx, log) => {
+    log.info('resolving boolean value');
+    return Promise.resolve({ value });
+  }),
+  resolveStringEvaluation: jest.fn((key, value, ctx, log) => {
+    log.info('resolving string value');
+    return Promise.resolve({ value });
+  }),
+  resolveNumberEvaluation: jest.fn((key, value, ctx, log) => {
+    log.info('resolving number value');
+    return Promise.resolve({ value });
+  }),
+  resolveObjectEvaluation: jest.fn((key, value, ctx, log) => {
+    log.info('resolving object value');
+>>>>>>> add logger
     return Promise.resolve({ value });
   }),
 };
@@ -91,7 +117,11 @@ describe('Logger', () => {
     describe('Safe Logger', () => {
       it('should use the default logger because the custom logger is missing a function', () => {
         const errorSpy = jest.spyOn(global.console, 'error').mockImplementation();
+<<<<<<< HEAD
         const safeLogger = new SafeLogger({} as Logger);
+=======
+        const safeLogger = new SafeLogger({} as any);
+>>>>>>> add logger
 
         expect(errorSpy).toBeCalledWith(
           expect.objectContaining({ message: 'The provided logger is missing the error method.' })
@@ -131,7 +161,11 @@ describe('Logger', () => {
       });
 
       it('should create a safe logger', () => {
+<<<<<<< HEAD
         OpenFeature.logger = {} as Logger;
+=======
+        OpenFeature.logger = {} as any;
+>>>>>>> add logger
         expect(OpenFeature.logger).toBeInstanceOf(SafeLogger);
       });
     });
@@ -147,7 +181,11 @@ describe('Logger', () => {
       const mockedLogger = new MockedLogger();
       client.logger = mockedLogger;
       await client.getBooleanValue('test', false);
+<<<<<<< HEAD
       expect(mockedLogger.info).toHaveBeenCalledWith(RESOLVE_BOOL_MESSAGE);
+=======
+      expect(mockedLogger.info).toHaveBeenCalledWith('resolving boolean value');
+>>>>>>> add logger
     });
 
     it('should provide a logger to the before, after, and finally hook', async () => {
@@ -158,6 +196,7 @@ describe('Logger', () => {
       await client.getBooleanValue('test', false);
 
       expect(mockedLogger.info.mock.calls).toEqual([
+<<<<<<< HEAD
         [BEFORE_HOOK_LOG_MESSAGE],
         [RESOLVE_BOOL_MESSAGE],
         [AFTER_HOOK_LOG_MESSAGE],
@@ -166,17 +205,31 @@ describe('Logger', () => {
     });
 
     it('should provide a logger to the error hook', async () => {
+=======
+        ['in before hook'],
+        ['resolving boolean value'],
+        ['in after hook'],
+        ['in finally hook'],
+      ]);
+    });
+
+    it('should use the default logger in the error hook', async () => {
+>>>>>>> add logger
       const client = OpenFeature.getClient();
       const mockedLogger = new MockedLogger();
       client.logger = mockedLogger;
       client.addHooks(MOCK_HOOK);
       (MOCK_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockRejectedValueOnce('Run error hook');
       await client.getBooleanValue('test', false);
+<<<<<<< HEAD
       expect(mockedLogger.info.mock.calls).toEqual([
         [BEFORE_HOOK_LOG_MESSAGE],
         [ERROR_HOOK_LOG_MESSAGE],
         [FINALLY_HOOK_LOG_MESSAGE],
       ]);
+=======
+      expect(mockedLogger.info.mock.calls).toEqual([['in before hook'], ['in error hook'], ['in finally hook']]);
+>>>>>>> add logger
     });
   });
 });

--- a/test/open-feature.spec.ts
+++ b/test/open-feature.spec.ts
@@ -1,4 +1,5 @@
 import { OpenFeatureClient } from '../src/client.js';
+import { NOOP_PROVIDER } from '../src/no-op-provider.js';
 import { OpenFeature } from '../src/open-feature.js';
 import { Provider } from '../src/types.js';
 
@@ -39,5 +40,16 @@ describe('OpenFeature', () => {
       expect(namedClient).toBeInstanceOf(OpenFeatureClient);
       expect(namedClient.metadata.name).toEqual(name);
     });
+  });
+
+  it('should be chainable', () => {
+    const client = OpenFeature.addHooks()
+      .clearHooks()
+      .setContext({})
+      .setLogger(console)
+      .setProvider(NOOP_PROVIDER)
+      .getClient();
+
+    expect(client).toBeDefined();
   });
 });


### PR DESCRIPTION
Updated various touchpoints in the global API and client to be chainable methods. This is a breaking change that is intended to provide a more consistent developer experience.