### PR TITLE
feat!: improve generic type accuracy

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import {
   FlagValueType,
   Hook,
   HookContext,
+  JsonValue,
   Logger,
   Provider,
   ResolutionDetails,
@@ -154,38 +155,39 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that returns a string.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {string} defaultValue The value returned if an error occurs
+   * @param {T extends string} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<string>} Flag evaluation response
+   * @returns {Promise<T extends string>} Flag evaluation response
    */
-  async getStringValue(
+  async getStringValue<T extends string = string>(
     flagKey: string,
-    defaultValue: string,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<string> {
-    return (await this.getStringDetails(flagKey, defaultValue, context, options)).value;
+  ): Promise<T> {
+    return (await this.getStringDetails<T>(flagKey, defaultValue, context, options)).value;
   }
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {boolean} defaultValue The value returned if an error occurs
+   * @param {T extends string} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<EvaluationDetails<string>>} Flag evaluation details response
+   * @returns {Promise<EvaluationDetails<T extends string>>} Flag evaluation details response
    */
-  getStringDetails(
+  getStringDetails<T extends string = string>(
     flagKey: string,
-    defaultValue: string,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<EvaluationDetails<string>> {
-    return this.evaluate<string>(
+  ): Promise<EvaluationDetails<T>> {
+    return this.evaluate<T>(
       flagKey,
-      this._provider.resolveStringEvaluation,
+      // this isolates providers from our restricted string generic argument.
+      this._provider.resolveStringEvaluation as () => Promise<EvaluationDetails<T>>,
       defaultValue,
       'string',
       context,
@@ -197,17 +199,17 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that returns a number.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {number} defaultValue The value returned if an error occurs
+   * @param {T extends number} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {Promise<number>} Flag evaluation response
    */
-  async getNumberValue(
+  async getNumberValue<T extends number = number>(
     flagKey: string,
-    defaultValue: number,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<number> {
+  ): Promise<T> {
     return (await this.getNumberDetails(flagKey, defaultValue, context, options)).value;
   }
 
@@ -215,20 +217,21 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that a returns an evaluation details object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {number} defaultValue The value returned if an error occurs
+   * @param {T extends number} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<EvaluationDetails<number>>} Flag evaluation details response
+   * @returns {Promise<EvaluationDetails<T extends number>>} Flag evaluation details response
    */
-  getNumberDetails(
+  getNumberDetails<T extends number = number>(
     flagKey: string,
-    defaultValue: number,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<EvaluationDetails<number>> {
-    return this.evaluate<number>(
+  ): Promise<EvaluationDetails<T>> {
+    return this.evaluate<T>(
       flagKey,
-      this._provider.resolveNumberEvaluation,
+      // this isolates providers from our restricted number generic argument.
+      this._provider.resolveNumberEvaluation as () => Promise<EvaluationDetails<T>>,
       defaultValue,
       'number',
       context,
@@ -240,12 +243,12 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that returns an object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {object} defaultValue The value returned if an error occurs
+   * @param {T extends JsonValue} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<object>} Flag evaluation response
+   * @returns {Promise<T extends JsonValu>} Flag evaluation response
    */
-  async getObjectValue<T extends object>(
+  async getObjectValue<T extends JsonValue = JsonValue>(
     flagKey: string,
     defaultValue: T,
     context?: EvaluationContext,
@@ -258,12 +261,12 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that a returns an evaluation details object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {object} defaultValue The value returned if an error occurs
+   * @param {T extends JsonValue} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<EvaluationDetails<object>>} Flag evaluation details response
+   * @returns {Promise<EvaluationDetails<T extends JsonValue>>} Flag evaluation details response
    */
-  getObjectDetails<T extends object>(
+  getObjectDetails<T extends JsonValue = JsonValue>(
     flagKey: string,
     defaultValue: T,
     context?: EvaluationContext,

--- a/src/client.ts
+++ b/src/client.ts
@@ -155,10 +155,11 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that returns a string.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {T extends string} defaultValue The value returned if an error occurs
+   * @template {string} T A optional generic argument constraining the string
+   * @param {T} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<T extends string>} Flag evaluation response
+   * @returns {Promise<T>} Flag evaluation response
    */
   async getStringValue<T extends string = string>(
     flagKey: string,
@@ -173,10 +174,11 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that a returns an evaluation details object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {T extends string} defaultValue The value returned if an error occurs
+   * @template {string} T A optional generic argument constraining the string
+   * @param {T} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<EvaluationDetails<T extends string>>} Flag evaluation details response
+   * @returns {Promise<EvaluationDetails<T>>} Flag evaluation details response
    */
   getStringDetails<T extends string = string>(
     flagKey: string,
@@ -199,10 +201,11 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that returns a number.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {T extends number} defaultValue The value returned if an error occurs
+   * @template {number} T A optional generic argument constraining the number
+   * @param {T} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<number>} Flag evaluation response
+   * @returns {Promise<T>} Flag evaluation response
    */
   async getNumberValue<T extends number = number>(
     flagKey: string,
@@ -217,10 +220,11 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that a returns an evaluation details object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {T extends number} defaultValue The value returned if an error occurs
+   * @template {number} T A optional generic argument constraining the number
+   * @param {T} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<EvaluationDetails<T extends number>>} Flag evaluation details response
+   * @returns {Promise<EvaluationDetails<T>>} Flag evaluation details response
    */
   getNumberDetails<T extends number = number>(
     flagKey: string,
@@ -243,10 +247,11 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that returns an object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {T extends JsonValue} defaultValue The value returned if an error occurs
+   * @template {JsonValue} T A optional generic argument describing the structure
+   * @param {T} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<T extends JsonValu>} Flag evaluation response
+   * @returns {Promise<T>} Flag evaluation response
    */
   async getObjectValue<T extends JsonValue = JsonValue>(
     flagKey: string,
@@ -261,10 +266,11 @@ export class OpenFeatureClient implements Client {
    * Performs a flag evaluation that a returns an evaluation details object.
    *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
-   * @param {T extends JsonValue} defaultValue The value returned if an error occurs
+   * @template {JsonValue} T A optional generic argument describing the structure
+   * @param {T} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
-   * @returns {Promise<EvaluationDetails<T extends JsonValue>>} Flag evaluation details response
+   * @returns {Promise<EvaluationDetails<T>>} Flag evaluation details response
    */
   getObjectDetails<T extends JsonValue = JsonValue>(
     flagKey: string,

--- a/src/no-op-provider.ts
+++ b/src/no-op-provider.ts
@@ -1,4 +1,4 @@
-import { Provider, ResolutionDetails } from './types';
+import { JsonValue, Provider, ResolutionDetails } from './types';
 
 const REASON_NO_OP = 'No-op';
 
@@ -22,7 +22,7 @@ class NoopFeatureProvider implements Provider {
     return this.noOp(defaultValue);
   }
 
-  resolveObjectEvaluation<T extends object>(_: string, defaultValue: T): Promise<ResolutionDetails<T>> {
+  resolveObjectEvaluation<T extends JsonValue>(_: string, defaultValue: T): Promise<ResolutionDetails<T>> {
     return this.noOp<T>(defaultValue);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,32 @@
-/**
- * Represents a JSON value of a JSON object
- */
-export type JSONValue = null | string | number | boolean | Date | { [x: string]: JSONValue } | Array<JSONValue>;
+type PrimitiveValue = null | boolean | string | number ;
 
+export type JsonObject = { [key: string]: JsonValue };
+
+export type JsonArray = JsonValue[];
+
+/**
+ * Represents a JSON node value.
+ */
+export type JsonValue = PrimitiveValue | JsonObject | JsonArray;
+
+/**
+ * Represents a JSON node value, or Date.
+ */
+export type EvaluationContextValue = PrimitiveValue | Date | { [key: string]: EvaluationContextValue } | EvaluationContextValue[];
+
+/**
+ * A container for arbitrary contextual data that can be used as a basis for dynamic evaluation
+ */
 export type EvaluationContext = {
   /**
    * A string uniquely identifying the subject (end-user, or client service) of a flag evaluation.
-   * Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users. Such providers may behave unpredictably if a targeting key is not specified at flag resolution.
+   * Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users.
+   * Such providers may behave unpredictably if a targeting key is not specified at flag resolution.
    */
   targetingKey?: string;
-} & Record<string, JSONValue>;
+} & Record<string, EvaluationContextValue>;
 
-export type FlagValue = boolean | string | number | object;
+export type FlagValue = boolean | string | number | JsonValue;
 
 export type FlagValueType = 'boolean' | 'string' | 'number' | 'object';
 
@@ -51,47 +66,47 @@ export interface Features {
   /**
    * Get a string flag value.
    */
-  getStringValue(
+  getStringValue<T extends string = string>(
     flagKey: string,
-    defaultValue: string,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<string>;
+  ): Promise<T>;
 
   /**
    * Get a string flag with additional details.
    */
-  getStringDetails(
+  getStringDetails<T extends string = string>(
     flagKey: string,
-    defaultValue: string,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<EvaluationDetails<string>>;
+  ): Promise<EvaluationDetails<T>>;
 
   /**
    * Get a number flag value.
    */
-  getNumberValue(
+  getNumberValue<T extends number = number>(
     flagKey: string,
-    defaultValue: number,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<number>;
+  ): Promise<T>;
 
   /**
    * Get a number flag with additional details.
    */
-  getNumberDetails(
+  getNumberDetails<T extends number = number>(
     flagKey: string,
-    defaultValue: number,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<EvaluationDetails<number>>;
+  ): Promise<EvaluationDetails<T>>;
 
   /**
    * Get an object (JSON) flag value.
    */
-  getObjectValue<T extends object>(
+  getObjectValue<T extends JsonValue = JsonValue>(
     flagKey: string,
     defaultValue: T,
     context?: EvaluationContext,
@@ -101,12 +116,12 @@ export interface Features {
   /**
    * Get an object (JSON) flag with additional details.
    */
-  getObjectDetails<T extends object>(
+  getObjectDetails(
     flagKey: string,
-    defaultValue: T,
+    defaultValue: JsonValue,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
-  ): Promise<EvaluationDetails<T>>;
+  ): Promise<EvaluationDetails<JsonValue>>;
 }
 
 /**
@@ -158,12 +173,12 @@ export interface Provider {
   /**
    * Resolve and parse an object flag and its evaluation details.
    */
-  resolveObjectEvaluation<U extends object>(
+  resolveObjectEvaluation<T extends JsonValue>(
     flagKey: string,
-    defaultValue: U,
+    defaultValue: T,
     context: EvaluationContext,
     logger: Logger
-  ): Promise<ResolutionDetails<U>>;
+  ): Promise<ResolutionDetails<T>>;
 }
 
 export enum StandardResolutionReasons {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,12 @@ export interface Features {
   /**
    * Get a string flag value.
    */
+   getStringValue(
+    flagKey: string,
+    defaultValue: string,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions
+  ): Promise<string>;
   getStringValue<T extends string = string>(
     flagKey: string,
     defaultValue: T,
@@ -76,6 +82,12 @@ export interface Features {
   /**
    * Get a string flag with additional details.
    */
+  getStringDetails(
+    flagKey: string,
+    defaultValue: string,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions
+  ): Promise<EvaluationDetails<string>>;
   getStringDetails<T extends string = string>(
     flagKey: string,
     defaultValue: T,
@@ -86,6 +98,12 @@ export interface Features {
   /**
    * Get a number flag value.
    */
+  getNumberValue(
+    flagKey: string,
+    defaultValue: number,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions
+  ): Promise<number>;
   getNumberValue<T extends number = number>(
     flagKey: string,
     defaultValue: T,
@@ -96,6 +114,12 @@ export interface Features {
   /**
    * Get a number flag with additional details.
    */
+   getNumberDetails(
+    flagKey: string,
+    defaultValue: number,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions
+  ): Promise<EvaluationDetails<number>>;
   getNumberDetails<T extends number = number>(
     flagKey: string,
     defaultValue: T,
@@ -106,6 +130,12 @@ export interface Features {
   /**
    * Get an object (JSON) flag value.
    */
+  getObjectValue(
+    flagKey: string,
+    defaultValue: JsonValue,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions
+  ): Promise<JsonValue>;
   getObjectValue<T extends JsonValue = JsonValue>(
     flagKey: string,
     defaultValue: T,
@@ -122,6 +152,12 @@ export interface Features {
     context?: EvaluationContext,
     options?: FlagEvaluationOptions
   ): Promise<EvaluationDetails<JsonValue>>;
+  getObjectDetails<T extends JsonValue = JsonValue>(
+    flagKey: string,
+    defaultValue: T,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions
+  ): Promise<EvaluationDetails<T>>;
 }
 
 /**

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -115,7 +115,7 @@ describe('OpenFeatureClient', () => {
           it('should return string, and call string resolver', async () => {
             const stringFlag = 'my-string-flag';
             const defaultStringValue = 'default-value';
-            const value = await client.getStringValue(stringFlag, defaultStringValue);
+            const value: string = await client.getStringValue(stringFlag, defaultStringValue);
   
             expect(value).toEqual(STRING_VALUE);
             expect(MOCK_PROVIDER.resolveStringEvaluation).toHaveBeenCalledWith(stringFlag, defaultStringValue, {}, {});
@@ -127,7 +127,7 @@ describe('OpenFeatureClient', () => {
             const stringFlag = 'my-string-flag';
             type MyRestrictedString = 'val' | 'other';
             const defaultStringValue = 'other';
-            const value = await client.getStringValue<MyRestrictedString>(stringFlag, defaultStringValue);
+            const value: MyRestrictedString = await client.getStringValue<MyRestrictedString>(stringFlag, defaultStringValue);
   
             expect(value).toEqual(STRING_VALUE);
             expect(MOCK_PROVIDER.resolveStringEvaluation).toHaveBeenCalledWith(stringFlag, defaultStringValue, {}, {});
@@ -140,7 +140,7 @@ describe('OpenFeatureClient', () => {
           it('should return number, and call number resolver', async () => {
             const numberFlag = 'my-number-flag';
             const defaultNumberValue = 1970;
-            const value = await client.getNumberValue(numberFlag, defaultNumberValue);
+            const value: number = await client.getNumberValue(numberFlag, defaultNumberValue);
   
             expect(value).toEqual(NUMBER_VALUE);
             expect(MOCK_PROVIDER.resolveNumberEvaluation).toHaveBeenCalledWith(numberFlag, defaultNumberValue, {}, {});
@@ -152,7 +152,7 @@ describe('OpenFeatureClient', () => {
             const numberFlag = 'my-number-flag';
             type MyRestrictedNumber = 4096 | 2048;
             const defaultNumberValue = 4096;
-            const value = await client.getNumberValue<MyRestrictedNumber>(numberFlag, defaultNumberValue);
+            const value: MyRestrictedNumber = await client.getNumberValue<MyRestrictedNumber>(numberFlag, defaultNumberValue);
   
             expect(value).toEqual(NUMBER_VALUE);
             expect(MOCK_PROVIDER.resolveNumberEvaluation).toHaveBeenCalledWith(numberFlag, defaultNumberValue, {}, {});
@@ -166,7 +166,7 @@ describe('OpenFeatureClient', () => {
           it('should return JsonValue, and call object resolver', async () => {
             const objectFlag = 'my-object-flag';
             const defaultObjectFlag = {};
-            const value = await client.getObjectValue(objectFlag, defaultObjectFlag);
+            const value: JsonValue = await client.getObjectValue(objectFlag, defaultObjectFlag);
   
             // compare the object
             expect(value).toEqual(OBJECT_VALUE);
@@ -197,12 +197,12 @@ describe('OpenFeatureClient', () => {
               } 
             }
 
-            const defaultMyTYpeFlag: MyType = {
+            const defaultMyTypeFlag: MyType = {
               inner: {
                 booleanKey: false
               }
             };
-            const value = await client.getObjectValue<MyType>(objectFlag, defaultMyTYpeFlag);
+            const value: MyType = await client.getObjectValue<MyType>(objectFlag, defaultMyTypeFlag);
   
             const innerBooleanValue: boolean = value.inner.booleanKey;
             expect(innerBooleanValue).toBeTruthy();

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,4 +1,3 @@
-import { json } from 'stream/consumers';
 import { OpenFeatureClient } from '../src/client.js';
 import { ERROR_REASON, GENERAL_ERROR } from '../src/constants.js';
 import { OpenFeature } from '../src/open-feature.js';

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+}


### PR DESCRIPTION
- restricts generic args on object resolver (`T` is now `T extends JsonValue`)
- adds optional generic args for string/number resolver for unions of string/number literals